### PR TITLE
Capturing `nil` metric source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sensu-plugins-prometheus-checks (2.3.0)
+    sensu-plugins-prometheus-checks (2.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sensu/plugins/prometheus/checks/runner.rb
+++ b/lib/sensu/plugins/prometheus/checks/runner.rb
@@ -154,7 +154,7 @@ module Sensu
                   "custom_#{name}",
                   output,
                   status,
-                  metric['source']
+                  metric['source'] || '<<UNKNOWN_SOURCE>>'
                 )
               end
             end
@@ -224,7 +224,7 @@ module Sensu
               log.info("[node_exporter] instance: '#{source}', nodename: '#{nodename}'")
               map[source] = nodename
             end
-            log.warn('Unable to query the node_exporter intances from Prometheus') \
+            log.warn('Unable to query the node_exporter instances from Prometheus') \
               if map.empty?
             map
           end

--- a/lib/sensu/plugins/prometheus/checks/version.rb
+++ b/lib/sensu/plugins/prometheus/checks/version.rb
@@ -2,7 +2,7 @@ module Sensu
   module Plugins
     module Prometheus
       module Checks
-        VERSION = '2.3.0'.freeze
+        VERSION = '2.3.1'.freeze
       end
     end
   end


### PR DESCRIPTION
When `source` is empty using a dummy string.