### PR TITLE
Fix custom source name for IP address instances

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sensu-plugins-prometheus-checks (3.1.1)
+    sensu-plugins-prometheus-checks (3.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sensu/plugins/prometheus/checks/runner.rb
+++ b/lib/sensu/plugins/prometheus/checks/runner.rb
@@ -235,10 +235,6 @@ module Sensu
           # "source" against "source_nodename_map" and composing "address" using
           # configuration "domain" entry.
           def append_event(name, output, status, source)
-            log.info(
-              "[#{status}] check: '#{name}', output: '#{output}', source: '#{source}'"
-            )
-
             # let source-nodename mapping avialable
             @source_nodename_map = source_nodename_map \
               if @source_nodename_map.nil?
@@ -246,6 +242,10 @@ module Sensu
             # translating node_exporter hostname into nodename plus domain
             nodename = @source_nodename_map[source] || source
             address = "#{nodename}.#{@config['config']['domain']}"
+
+            log.info(
+              "[#{status}] check: '#{name}', output: '#{output}', source: '#{nodename}'"
+            )
 
             @events << {
               'address' => sensu_safe(address),

--- a/lib/sensu/plugins/prometheus/checks/version.rb
+++ b/lib/sensu/plugins/prometheus/checks/version.rb
@@ -2,7 +2,7 @@ module Sensu
   module Plugins
     module Prometheus
       module Checks
-        VERSION = '3.1.1'.freeze
+        VERSION = '3.1.2'.freeze
       end
     end
   end

--- a/lib/sensu/plugins/prometheus/metrics.rb
+++ b/lib/sensu/plugins/prometheus/metrics.rb
@@ -20,7 +20,7 @@ module Sensu
         def custom(cfg)
           metrics = []
           @client.query(cfg['query']).each do |result|
-            source = if result['metric']['instance'] =~ /^\d+/
+            source = if result['metric'].key? 'app'
                        result['metric']['app']
                      else
                        result['metric']['instance']

--- a/spec/cassettes/Sensu_Plugins_Prometheus_Metrics/_custom_with_ip_address.yml
+++ b/spec/cassettes/Sensu_Plugins_Prometheus_Metrics/_custom_with_ip_address.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:19090/api/v1/query?query=up
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, Origin
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Aug 2017 09:36:04 GMT
+      Content-Length:
+      - '989'
+    body:
+      encoding: UTF-8
+      string: '{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","instance":"10.100.0.239:9100","job":"etcd"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.253:9100","job":"nodes"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.238:9100","job":"masters"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.36:9100","job":"nodes"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.249:9100","job":"nodes"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.77:9100","job":"masters"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.137:9100","job":"etcd"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.108:9100","job":"etcd"},"value":[1502357764.476,"1"]},{"metric":{"__name__":"up","instance":"10.100.0.58:9100","job":"masters"},"value":[1502357764.476,"1"]}]}}'
+    http_version: 
+  recorded_at: Thu, 10 Aug 2017 09:36:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/sensu/plugins/prometheus/metrics_spec.rb
+++ b/spec/sensu/plugins/prometheus/metrics_spec.rb
@@ -21,6 +21,19 @@ describe Sensu::Plugins::Prometheus::Metrics, :vcr do
     expect(results).to include('source' => 'node-exporter2:9100', 'value' => '1')
   end
 
+  it '.custom_with_ip_address' do
+    cfg = {
+      'name' => 'heartbeat',
+      'query' => 'up',
+      'check' => {
+        'type' => 'equals',
+        'value' => 1
+      }
+    }
+    results = metrics.custom(cfg)
+    expect(results).to include('source' => '10.100.0.239:9100', 'value' => '1')
+  end
+
   context '.disk' do
     it 'checks the disk usage with a default name for a root partition' do
       cfg = { 'mount' => '/' }


### PR DESCRIPTION
Custom metrics were defaulting the the `app` value from a metric when the instance name was an IP address. Now it is only using the `app` value when it exists and then defaulting to the instance name. This resulted in empty source names for custom metrics coming from instances being scrapped by IP address. 